### PR TITLE
Use display: contents in wrapper div

### DIFF
--- a/lib/live_monaco_editor.ex
+++ b/lib/live_monaco_editor.ex
@@ -87,7 +87,7 @@ defmodule LiveMonacoEditor do
     assigns = assign(assigns, :opts, opts)
 
     ~H"""
-    <div id={"lme-wrapper-code-#{random_id()}"} phx-update="ignore">
+    <div id={"lme-wrapper-code-#{random_id()}"} phx-update="ignore" style="display: contents">
       <div
         id={"lme-code-#{random_id()}"}
         style={@style}


### PR DESCRIPTION
The lme wrapper div's display should be set to `contents` so you can specify it's childs size

> display: contents causes an element's children to appear as if they were direct children of the element's parent, ignoring the element itself. This can be useful when a wrapper element should be ignored when using CSS grid or similar layout techniques.

https://caniuse.com/css-display-contents