### PR TITLE
Add support for targeted events.

### DIFF
--- a/assets/js/live_monaco_editor/editor/code_editor.js
+++ b/assets/js/live_monaco_editor/editor/code_editor.js
@@ -66,24 +66,24 @@ class CodeEditor {
 
       this._setScreenDependantEditorOptions()
 
-      this.editor.addAction({
+      this.standalone_code_editor.addAction({
         contextMenuGroupId: "word-wrapping",
         id: "enable-word-wrapping",
         label: "Enable word wrapping",
         precondition: "config.editor.wordWrap == off",
         keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
         run: (editor) => editor.updateOptions({ wordWrap: "on" }),
-      });
+      })
 
-      this.editor.addAction({
+      this.standalone_code_editor.addAction({
         contextMenuGroupId: "word-wrapping",
         id: "disable-word-wrapping",
         label: "Disable word wrapping",
         precondition: "config.editor.wordWrap == on",
         keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
         run: (editor) => editor.updateOptions({ wordWrap: "off" }),
-      });
-      
+      })
+
       const resizeObserver = new ResizeObserver((entries) => {
         entries.forEach(() => {
           if (this.el.offsetHeight > 0) {

--- a/assets/js/live_monaco_editor/hooks/code_editor.js
+++ b/assets/js/live_monaco_editor/hooks/code_editor.js
@@ -15,9 +15,19 @@ const CodeEditorHook = {
     this.codeEditor.onMount((monaco) => {
       if (this.el.dataset.changeEvent && this.el.dataset.changeEvent !== "") {
         this.codeEditor.standalone_code_editor.onDidChangeModelContent(() => {
-          this.pushEvent(this.el.dataset.changeEvent, {
-            value: this.codeEditor.standalone_code_editor.getValue(),
-          })
+          if (this.el.dataset.target && this.el.dataset.target !== "") {
+            this.pushEventTo(
+              this.el.dataset.target,
+              this.el.dataset.changeEvent,
+              {
+                value: this.codeEditor.standalone_code_editor.getValue(),
+              }
+            )
+          } else {
+            this.pushEvent(this.el.dataset.changeEvent, {
+              value: this.codeEditor.standalone_code_editor.getValue(),
+            })
+          }
         })
       }
 

--- a/lib/live_monaco_editor.ex
+++ b/lib/live_monaco_editor.ex
@@ -77,6 +77,11 @@ defmodule LiveMonacoEditor do
     doc:
       "event name to capture editor content changes, see https://github.com/BeaconCMS/live_monaco_editor#inside-forms for more info"
 
+  attr :target, :string,
+    default: "",
+    doc:
+      "target for editor events in order to use with LiveComponent, see https://github.com/BeaconCMS/live_monaco_editor#inside-forms for more info"
+
   attr :opts, :map,
     default: @default_opts,
     doc: """
@@ -113,6 +118,7 @@ defmodule LiveMonacoEditor do
         data-path={@path}
         data-value={@value}
         data-change-event={@change}
+        data-target={@target}
         data-opts={@opts}
         {@rest}
       >


### PR DESCRIPTION
This PR adds `target` attribute to `code_editor` component. It works like `phx-target` and can be used like this:

```heex
<LiveMonacoEditor.code_editor value={@value} change="code_change_event" target={@myself} />
```

This is necessary if you want to use editor as part of LiveComponent.